### PR TITLE
Ensure the decoded frame is in AV_SAMPLE_FMT_S16 or audio will be distorted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 # http://www.gnu.org/software/make/manual/make.html
 #
 CC:=gcc
-INCLUDES:=$(shell pkg-config --cflags libavformat libavcodec libswscale libavutil sdl)
+INCLUDES:=$(shell pkg-config --cflags libavformat libavcodec libswresample libswscale libavutil sdl)
 CFLAGS:=-Wall -ggdb
-LDFLAGS:=$(shell pkg-config --libs libavformat libavcodec libswscale libavutil sdl) -lm
+LDFLAGS:=$(shell pkg-config --libs libavformat libavcodec libswresample libswscale libavutil sdl) -lm
 EXE:=tutorial01.out tutorial02.out tutorial03.out tutorial04.out\
 	tutorial05.out tutorial06.out tutorial07.out
 


### PR DESCRIPTION
I modified the example to account for changes in the new version of FFmpeg. Newer versions of FFmpeg don't always decode frames in AV_SAMPLE_FMT_S16 format. This can cause the audio playback to be distorted when using the current SDL config. I modified to the code to convert frame to AV_SAMPLE_FMT_S16 if they aren't in that format already. You don't have to merge my changes but hopefully this will be useful in case someone else encounters this issue,